### PR TITLE
Add polyfill for IE11

### DIFF
--- a/src/components/kalendar-components/kalendar-cell.vue
+++ b/src/components/kalendar-components/kalendar-cell.vue
@@ -20,6 +20,8 @@
 import differenceInHours from 'date-fns/difference_in_hours';
 import format from 'date-fns/format';
 
+const crypto = window.crypto || window.msCrypto; // IE11 Polyfill
+
 export default {
 	props: ['creator', 'day', 'index', 'cellData'],
 	inject: ['calendarOptions'],

--- a/src/components/kalendar-components/kalendar-container.vue
+++ b/src/components/kalendar-components/kalendar-container.vue
@@ -68,6 +68,7 @@ import "./filters";
 Vue.use(PortalVue);
 
 smoothscroll.polyfill();
+const crypto = window.crypto || window.msCrypto; // IE11 Polyfill
 
 const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 


### PR DESCRIPTION
I want to fix #2 by adding the IE11 polyfill for the global crypto variable.

This code is not the most DRY as I have the polyfill in 2 places, but was not sure what type of folder structure for util style exports was wanted.

Not included is any typings files. Should i include an update to the readme to include how to shim for types? or should that be a separate PR?
```
declare module 'kalendar-vue';
declare global {
  interface Window{
    msCrypto: Crypto;
  }
}
```