### PR TITLE
add military time config param, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ components: {
 			cell_height: 20, // !isNaN(Value)
 			scrollToNow: true, // Boolean
 			current_day: new Date(), // Valid date
+			military_time: true, // Boolean
 		},
 		...
 	})

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -23,6 +23,9 @@
             <option value="30">30 minutes</option>
           </select>
         </label>
+        <label>24 Hour Time
+          <input type="checkbox" v-model="military_time">
+        </label>
       </div>
     </div>
     <kalendar :configuration="config" :appointments="appointments" ref="calendar-component">
@@ -113,6 +116,7 @@ export default {
       description: null,
       title: null,
     },
+    military_time: true,
   }),
   components: {
     kalendar,
@@ -124,6 +128,7 @@ export default {
         style: this.style,
         view_type: this.view_type,
         scrollToNow: true,
+        military_time: this.military_time,
       }
     },
   },

--- a/src/components/kalendar-components/kalendar-container.vue
+++ b/src/components/kalendar-components/kalendar-container.vue
@@ -110,6 +110,7 @@ export default {
       existing_appointments: {},
       style: 'material_design',
       now: new Date,
+      military_time: true,
     },
     weeks: {},
     hours: [],

--- a/src/components/kalendar-components/kalendar-container.vue
+++ b/src/components/kalendar-components/kalendar-container.vue
@@ -137,6 +137,7 @@ export default {
           view_type: (val) => ['Month', 'Day'].includes(val),
           cell_height: (val) => !isNaN(val),
           style: (val) => ['material_design', 'flat_design'].includes(val),
+          military_time: (val) => typeof val === 'boolean',
         };
         for (let key in provided_props) {
           if (conditions.hasOwnProperty(key) && conditions[key](provided_props[key])) {

--- a/src/components/kalendar-components/kalendar-weekview.vue
+++ b/src/components/kalendar-components/kalendar-weekview.vue
@@ -22,7 +22,7 @@
       <div class="calendar-blocks">
         <ul class="hours">
           <li class="hour-row-identifier" v-for="hour in (hours || [])" :style="`height:${hourHeight}px`">
-            <span>{{formatDate(hour, 'H A')}}</span>
+            <span>{{formatDate(hour, military_time)}}</span>
           </li>
         </ul>
         <div v-show="calendarOptions.style !== 'material_design'" class="hour-indicator-line" :style="`top:calc(${passedtime.percentage}% - 5px)`">
@@ -79,6 +79,9 @@ export default {
         return this.existing_appointments || {};
       },
     },
+    military_time() {
+      return this.calendarOptions.military_time ? 'H A' : 'h A';
+    }
   },
   methods: {
     formatDate(_format, how) {

--- a/src/components/kalendar-components/kalendar-weekview.vue
+++ b/src/components/kalendar-components/kalendar-weekview.vue
@@ -22,7 +22,7 @@
       <div class="calendar-blocks">
         <ul class="hours">
           <li class="hour-row-identifier" v-for="hour in (hours || [])" :style="`height:${hourHeight}px`">
-            <span>{{formatDate(hour, military_time)}}</span>
+            <span>{{formatDate(hour, hour_format)}}</span>
           </li>
         </ul>
         <div v-show="calendarOptions.style !== 'material_design'" class="hour-indicator-line" :style="`top:calc(${passedtime.percentage}% - 5px)`">
@@ -79,7 +79,7 @@ export default {
         return this.existing_appointments || {};
       },
     },
-    military_time() {
+    hour_format() {
       return this.calendarOptions.military_time ? 'H A' : 'h A';
     }
   },


### PR DESCRIPTION
fixes #4 

I kept the default as true, as that is the current behavior.

I thought `military_time` was a good name for this.