### PR TITLE
Adding scope slots for date formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Useful for localizing dates
 | Slot name          | Slot scope         | Description                                       |
 |--------------------|--------------------|---------------------------------------------------|
 | first&#8209;date   | {&#160;date&#160;} | Displays first date in week navigation            |
-| last&#8209;date    | {&#160;date&#160;} | Displays last date in week nvagigation            |
+| last&#8209;date    | {&#160;date&#160;} | Displays last date in week navigation             |
 | current&#8209;date | {&#160;date&#160;} | Displays current date in single day navigation    |
 | number&#8209;date  | {&#160;date&#160;} | Displays day number in day indicators             |
 | letters&#8209;date | {&#160;date&#160;} | Displays weekday name in day indicators           |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ components: {
 },
 ```
 - Provide Appointments array. This array will be the source of the appointments which are rendered in the calendar.
-```html
+```vue
 <template>
 	<kalendar :configuration="calendar_settings" :appointments="appointments"/>
 </template>
@@ -54,7 +54,7 @@ components: {
 > The plugin can turn incredibly useful using scoped slots. You can customize all the essential parts of it.
 
 
-```html
+```vue
 <kalendar :configuration="calendar_settings" :appointments="appointments" class="generate-shadow">
 	<div slot="creating-card" slot-scope="{appointment_props}">
 		<!-- This is the card that is displayed while the user is dragging mouse on cells -->
@@ -83,6 +83,27 @@ components: {
 		<small v-show="(appointment_props.end - appointment_props.start) > 2">{{appointment_props.data.description}}</small>
 		<span class="time">{{appointment_props.start_value.value | normalizeDate('hh:mm A')}} - {{appointment_props.end_value.value | normalizeDate('hh:mm A')}}</span>
 	</div>
+	<!-- Date formatting -->
+	<template slot="first-date" slot-scope="{ date }">
+		<!-- Displays first date in week navigation header -->
+		{{ date | normalizeDate('MMM DD') }}
+	</template>
+	<template slot="last-date" slot-scope="{ date }">
+		<!-- Displays last date in week navigation header -->
+		{{ date | normalizeDate('DD MMM, YYYY') }}
+	</template>
+	<template slot="current-date" slot-scope="{ date }">
+		<!-- Displays current date in single day navigation -->
+		{{ date | normalizeDate('DD MMM, YYYY') }}
+	</template>
+	<template slot="number-date" slot-scope="{ date }">
+		<!-- Day number in day indicators -->
+		{{ date | normalizeDate('D') }}
+	</template>
+	<template slot="letters-date" slot-scope="{ date }">
+		<!-- Weekday name in day indicators -->
+		{{ date | normalizeDate('ddd') }}
+	</template>
 </kalendar>
 
 <script>
@@ -106,6 +127,28 @@ components: {
 	},
 </script>
 ```
+### Slots summary
+
+#### Appointment cards
+
+| Slot name           | Slot scope                      |  Description                                        |
+|---------------------|---------------------------------|-----------------------------------------------------|
+| creating&#8209;card | {&#160;appointment_props&#160;} | Displayed while the user is dragging mouse on cells |
+| details&#8209;card  | {&#160;appointment_props&#160;} | Similar to creating-card, except that this one is displayed for existing appointments |
+| popup&#8209;form    | {&#160;popup_scope&#160;}       | Displayed when user has finished dragging (selecting appointment start and end values) |
+
+#### Date representations
+Useful for localizing dates
+
+| Slot name          | Slot scope         | Description                                       |
+|--------------------|--------------------|---------------------------------------------------|
+| first&#8209;date   | {&#160;date&#160;} | Displays first date in week navigation            |
+| last&#8209;date    | {&#160;date&#160;} | Displays last date in week nvagigation            |
+| current&#8209;date | {&#160;date&#160;} | Displays current date in single day navigation    |
+| number&#8209;date  | {&#160;date&#160;} | Displays day number in day indicators             |
+| letters&#8209;date | {&#160;date&#160;} | Displays weekday name in day indicators           |
+
+
 ## Roadmap
 - Remove date-fns dependency
 - Improve performance
@@ -114,6 +157,6 @@ components: {
 	* Use event delegation and remove listeners from every cell. Use event target instead, to manipulate the cell DOM object.
 - Add month view
 - Write docs
-- Write unit-test
+- Write unit-tests
 - Write the React version of this plugin
 - Write the Angular version of this plugin

--- a/src/components/kalendar/kalendar-container.vue
+++ b/src/components/kalendar/kalendar-container.vue
@@ -6,17 +6,33 @@
           <div class="nav-wrapper">
             <button @click="previousWeek()" class="chevron left"></button>
             <div v-if="calendar_options.view_type === 'Month' && !!calendar_options.current_week">
-              <span>{{startOfWeek(calendar_options.current_week[0].date) | normalizeDate('MMM DD')}}</span>
-              <span style="margin:0px 5px;">-</span>
-              <span>{{endOfWeek(calendar_options.current_week[0].date) | normalizeDate('MMM DD, YYYY')}}</span>
+              <slot name="first-date" :date="startOfWeek(calendar_options.current_week[0].date)">
+                <span>{{ calendar_options.current_week[0].date | normalizeDate('MMM DD') }}</span>
+              </slot>
+              <span syle="margin:0px 5px;">-</span>
+              <slot name="last-date" :date="endOfWeek(calendar_options.current_week[0].date)">
+                <span>{{ calendar_options.current_week[0].date | normalizeDate('MMM DD, YYYY') }}</span>
+              </slot>
             </div>
             <div v-else>
-              <span>{{ calendar_options.current_day | normalizeDate('DD MMM, YYYY') }}</span>
+              <slot name="current-date" :date="calendar_options.current_day">
+                <span>{{ calendar_options.current_day | normalizeDate('DD MMM, YYYY') }}</span>
+              </slot>
             </div>
             <button @click="nextWeek()" class="chevron"></button>
           </div>
         </slot>
       </div>
+    </portal>
+    <portal to="number-date" class="slotable">
+      <span slot-scope="{ date }" class="number-date">
+        <slot name="number-date" :date="date">{{ formatDate(date, 'D') }}</slot>
+      </span>
+    </portal>
+    <portal to="letters-date" class="slotable">
+      <span slot-scope="{ date }" class="letters-date">
+        <slot name="letters-date" :date="date">{{ formatDate(date, 'ddd') }}</slot>
+      </span>
     </portal>
     <kalendar-week-view :days="calendar_options.current_week" :hours="hours"></kalendar-week-view>
     <portal to="calendar-card" class="slotable">

--- a/src/components/kalendar/kalendar-weekview.vue
+++ b/src/components/kalendar/kalendar-weekview.vue
@@ -4,8 +4,8 @@
       <portal-target name="week-navigator-place"></portal-target>
       <ul class="days">
         <li class="day-indicator" :key="index" v-for="({date}, index) in (days || [])" :class="{'today': _isToday(date), 'is-before': isBefore(date)}">
-          <span class="number-date">{{formatDate(date, 'D')}}</span>
-          <span class="letters-date">{{formatDate(date,'ddd')}}</span>
+          <portal-target name="number-date" :slot-props="{ date }"></portal-target>
+          <portal-target name="letters-date" :slot-props="{ date }"></portal-target>
         </li>
       </ul>
       <ul class="all-day">

--- a/src/components/kalendar/kalendar-weekview.vue
+++ b/src/components/kalendar/kalendar-weekview.vue
@@ -4,8 +4,8 @@
       <portal-target name="week-navigator-place"></portal-target>
       <ul class="days">
         <li class="day-indicator" :key="index" v-for="({date}, index) in (days || [])" :class="{'today': _isToday(date), 'is-before': isBefore(date)}">
-          <portal-target name="number-date" :slot-props="{ date }"></portal-target>
-          <portal-target name="letters-date" :slot-props="{ date }"></portal-target>
+          <portal-target name="number-date" :slot-props="{ date }" slim></portal-target>
+          <portal-target name="letters-date" :slot-props="{ date }" slim></portal-target>
         </li>
       </ul>
       <ul class="all-day">

--- a/src/demo/how-to.vue
+++ b/src/demo/how-to.vue
@@ -91,6 +91,27 @@ const slots = `
 		<small v-show="(appointment_props.end - appointment_props.start) > 2">{{appointment_props.data.description}}</small>
 		<span class="time">{{appointment_props.start_value.value | normalizeDate('hh:mm A')}} - {{appointment_props.end_value.value | normalizeDate('hh:mm A')}}</span>
 	</div>
+	<!-- Date formatting -->
+	<template slot="first-date" slot-scope="{ date }">
+		<!-- Displays first date in week navigation header -->
+		{{ date | normalizeDate('MMM DD') }}
+	</template>
+	<span slot="last-date" slot-scope="{ date }">
+		<!-- Displays last date in week navigation header -->
+		{{ date | normalizeDate('DD MMM, YYYY') }}
+	</template>
+	<template slot="current-date" slot-scope="{ date }">
+		<!-- Displays current date in single day navigation -->
+		{{ date | normalizeDate('DD MMM, YYYY') }}
+	</template>
+	<template slot="number-date" slot-scope="{ date }">
+		<!-- Day number in day indicators -->
+		{{ date | normalizeDate('D') }}
+	</template>
+	<template slot="letters-date" slot-scope="{ date }">
+		<!-- Weekday name in day indicators -->
+		{{ date | normalizeDate('ddd') }}
+	</template>
 </kalendar>
 `;
 

--- a/src/demo/how-to.vue
+++ b/src/demo/how-to.vue
@@ -96,7 +96,7 @@ const slots = `
 		<!-- Displays first date in week navigation header -->
 		{{ date | normalizeDate('MMM DD') }}
 	</template>
-	<span slot="last-date" slot-scope="{ date }">
+	<template slot="last-date" slot-scope="{ date }">
 		<!-- Displays last date in week navigation header -->
 		{{ date | normalizeDate('DD MMM, YYYY') }}
 	</template>

--- a/src/demo/index.vue
+++ b/src/demo/index.vue
@@ -103,6 +103,21 @@
 						<svg class="feather feather-x-circle sc-dnqmqq jxshSx" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" data-reactid="1326"><circle cx="12" cy="12" r="10"></circle><line x1="15" y1="9" x2="9" y2="15"></line><line x1="9" y1="9" x2="15" y2="15"></line></svg>
 					</button>
 				</div>
+				<template slot="first-date" slot-scope="{ date }">
+					{{ date | normalizeDate('MMM DD') }}
+				</template>
+				<template slot="last-date" slot-scope="{ date }">
+					{{ date | normalizeDate('DD MMM, YYYY') }}
+				</template>
+				<template slot="current-date" slot-scope="{ date }">
+					{{ date | normalizeDate('DD MMM, YYYY') }}
+				</template>
+				<template slot="number-date" slot-scope="{ date }">
+					{{ date | normalizeDate('D') }}
+				</template>
+				<template slot="letters-date" slot-scope="{ date }">
+					{{ date | normalizeDate('ddd') }}
+				</template>
 			</kalendar>
 		</div>
 		<how-to></how-to>


### PR DESCRIPTION
> This is a duplicate of #11 without the accidental tabs-to-spaces translation

This PR adds 5 more scoped slots to be able to customize date formating (i.e. for localization)

I updated the _demo_ and _how-to_ components, and added the corresponding notes to the README, also added a slots summary table for convenience.

This is perhaps a more robust approach to #10,  as my use case requires some i18n capabilites

Cheers!

The new slots look like this:

```vue
<Kalendar ...>
  <template slot="first-date" slot-scope="{ date }">
    <!-- Displays first date in week navigation header -->
    {{ date | normalizeDate('MMM DD') }}
  </template>
  <template slot="last-date" slot-scope="{ date }">
    <!-- Displays last date in week navigation header -->
    {{ date | normalizeDate('DD MMM, YYYY') }}
  </template>
  <template slot="current-date" slot-scope="{ date }">
    <!-- Displays current date in single day navigation -->
    {{ date | normalizeDate('DD MMM, YYYY') }}
  </template>
  <template slot="number-date" slot-scope="{ date }">
    <!-- Day number in day indicators -->
    {{ date | normalizeDate('D') }}
  </template>
  <template slot="letters-date" slot-scope="{ date }">
    <!-- Weekday name in day indicators -->
    {{ date | normalizeDate('ddd') }}
  </template>
  ...
</Kalendar>
```

### Slots summary

#### Appointment cards
| Slot name           | Slot scope                      |  Description                                        |
|---------------------|---------------------------------|-----------------------------------------------------|
| creating&#8209;card | {&#160;appointment_props&#160;} | Displayed while the user is dragging mouse on cells |
| details&#8209;card  | {&#160;appointment_props&#160;} | Similar to creating-card, except that this one is displayed for existing appointments |
| popup&#8209;form    | {&#160;popup_scope&#160;}       | Displayed when user has finished dragging (selecting appointment start and end values) |

#### Date representations
Useful for localizing dates

| Slot name          | Slot scope         | Description                                       |
|--------------------|--------------------|---------------------------------------------------|
| first&#8209;date   | {&#160;date&#160;} | Displays first date in week navigation            |
| last&#8209;date    | {&#160;date&#160;} | Displays last date in week nvagigation            |
| current&#8209;date | {&#160;date&#160;} | Displays current date in single day navigation    |
| number&#8209;date  | {&#160;date&#160;} | Displays day number in day indicators             |
| letters&#8209;date | {&#160;date&#160;} | Displays weekday name in day indicators           |
