### PR TITLE
Hide hour indicator when it's out of day bounds

### DIFF
--- a/src/lib-components/kalendar-day.vue
+++ b/src/lib-components/kalendar-day.vue
@@ -16,13 +16,15 @@
           ? 'hour-indicator-line'
           : 'hour-indicator-tooltip'
       "
-      v-if="isToday"
+      v-if="isToday && passedTimeVisible"
       :style="`top:${passedTime}px`"
+      v-show="passedTimeVisible"
     >
       <span
         class="line"
         v-show="kalendar_options.style === 'material_design'"
       ></span>
+      <!-- kalendar_options.style === 'material_design' && passedTimeVisible -->
     </div>
     <kalendar-cell
       v-for="(cell, index) in day_cells"
@@ -73,6 +75,9 @@ export default {
     },
     isToday() {
       return isToday(this.day.value);
+    },
+    passedTimeVisible() {
+      return this.passedTime > -1;
     }
   },
   data: () => ({

--- a/src/lib-components/kalendar-weekview.vue
+++ b/src/lib-components/kalendar-weekview.vue
@@ -50,7 +50,7 @@
           </li>
         </ul>
         <div
-          v-show="kalendar_options.style !== 'material_design'"
+          v-show="kalendar_options.style !== 'material_design' && passedTimeVisible"
           class="hour-indicator-line"
           :style="`top:${passedTime.distance}px`"
         >
@@ -116,18 +116,21 @@ export default {
       //this.kalendar_options.cell_height * (60 / this.kalendar_options.split_value);
       // * this.kalendar_options.hour_parts;
     },
+    passedTimeVisible() {
+      return this.passedTime > -1;
+    },
     passedTime() {
       let { day_starts_at, day_ends_at, now } = this.kalendar_options;
-      let time = getLocaleTime(now);
-      let day_starts = `${time.split("T")[0]}T${(day_starts_at + "").padStart(2, '0')}:00:00.000Z`;
-      let day_ends = `${time.split("T")[0]}T${(day_ends_at + "").padStart(2, '0')}:00:00.000Z`;
-      let time_obj = new Date(time);
+      let res = { distance: -1, time: getLocaleTime(now) };
+      let day_starts = `${res.time.split("T")[0]}T${(day_starts_at + "").padStart(2, '0')}:00:00.000Z`;
+      let day_ends = `${res.time.split("T")[0]}T${(day_ends_at + "").padStart(2, '0')}:00:00.000Z`;
+      let time_obj = new Date(res.time);
 
-      if(new Date(day_ends) < time_obj || time_obj < new Date(day_starts)) return null;
+      if(new Date(day_ends) < time_obj || time_obj < new Date(day_starts)) return res;
 
-      let distance = (time_obj - new Date(day_starts)) / 1000 / 60;
-      return {distance, time};
-    }
+      res.distance = (time_obj - new Date(day_starts)) / 1000 / 60;
+      return res;
+    },
   },
   methods: {
     _isToday(day) {


### PR DESCRIPTION
Related to and possibly closes issue #52:

The `passedTime()` function was returning null when current time was out of day bounds. So, `distance` prop was not exists. 
Changed to return the same `{distance, time}` object, but with distance value as -1.
Hour line is shown only when passes `passedTimeVisible` guard, added as computed prop. 